### PR TITLE
修复缓存目录命名并重构资源初始化流程

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import os
 import asyncio
 import aiofiles
 import aiofiles.os
-from .resources import ResourceManager 
+from .resources import ResourceManager
 from .painter import FortunePainter
 
 
@@ -17,13 +17,19 @@ class JrysPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
 
-        self.config = config    
-        self.resources = ResourceManager(self.config)
+        self.config = config
+        self.resources = ResourceManager(
+            self.config,
+            plugin_name=getattr(self, "name", None),
+        )
         self.painter = FortunePainter(self.config)
 
         # 是否启用关键词触发功能
         self.jrys_keyword_enabled = self.config.get("jrys_keyword_enabled", True)
 
+    async def initialize(self):
+        """插件加载后初始化资源管理器。"""
+        await self.resources.initialize()
 
     # 处理器1：指令处理器
     @filter.command("jrys", alias=["今日运势", "运势"])
@@ -46,14 +52,18 @@ class JrysPlugin(Star):
         self.jrys_data = await self.resources._load_jrys_data()
         user_last_images = self.jrys_data.get("_user_last_images", {})
         if user_id not in user_last_images:
-            yield event.plain_result("你还没有生成过今日运势哦，先发送 jrys 生成一张吧！")
+            yield event.plain_result(
+                "你还没有生成过今日运势哦，先发送 jrys 生成一张吧！"
+            )
             return
 
         last_info = user_last_images[user_id]
         path = last_info.get("path")
 
         if not path or not os.path.exists(path):
-            yield event.plain_result("找不到上一次生成的原图了，可能已被清理，请重新生成～")
+            yield event.plain_result(
+                "找不到上一次生成的原图了，可能已被清理，请重新生成～"
+            )
             return
 
         yield event.image_result(path)
@@ -87,15 +97,12 @@ class JrysPlugin(Star):
 
         self.jrys_data = await self.resources._load_jrys_data()
 
-
-
         logger.info(f"正在为用户 {user_name}({user_id}) 生成今日运势")
 
         background_path = None
         background_should_cleanup = False
 
         try:
-
             results = await asyncio.gather(
                 self.resources.get_avatar_img(user_id),
                 self.resources.get_background_image(),
@@ -119,7 +126,11 @@ class JrysPlugin(Star):
             if isinstance(avatar_path, Exception):
                 logger.error(f"获取头像时出错: {avatar_path}")
                 yield event.plain_result("获取头像失败，请稍后再试～")
-                if background_should_cleanup and background_path and os.path.exists(background_path):
+                if (
+                    background_should_cleanup
+                    and background_path
+                    and os.path.exists(background_path)
+                ):
                     try:
                         await aiofiles.os.remove(background_path)
                     except Exception:
@@ -134,10 +145,13 @@ class JrysPlugin(Star):
         temp_file_path = None  # 用于存储临时文件路径
 
         try:
-
             logger.info(f"正在为用户 {user_name}({user_id}) 生成今日运势图片")
             temp_file_path = await asyncio.to_thread(
-                self.painter.generate_image_sync, user_id, avatar_path, background_path, self.jrys_data
+                self.painter.generate_image_sync,
+                user_id,
+                avatar_path,
+                background_path,
+                self.jrys_data,
             )
 
             if temp_file_path is None:
@@ -151,26 +165,31 @@ class JrysPlugin(Star):
             # 保存最后一次使用的背景图信息到 jrys_data
             if "_user_last_images" not in self.jrys_data:
                 self.jrys_data["_user_last_images"] = {}
-            
+
             user_last_images = self.jrys_data["_user_last_images"]
             if user_id in user_last_images:
                 old_info = user_last_images[user_id]
                 old_path = old_info.get("path")
                 # 如果旧图是临时图且与新图不同，则删除旧图
-                if old_info.get("should_cleanup") and old_path and old_path != background_path and os.path.exists(old_path):
+                if (
+                    old_info.get("should_cleanup")
+                    and old_path
+                    and old_path != background_path
+                    and os.path.exists(old_path)
+                ):
                     try:
                         await aiofiles.os.remove(old_path)
-                    except:
+                    except Exception:
                         pass
-            
+
             user_last_images[user_id] = {
                 "path": background_path,
-                "should_cleanup": background_should_cleanup
+                "should_cleanup": background_should_cleanup,
             }
-            await self.resources._save_jrys_data() # 保存更新后的 jrys_data
-            
+            await self.resources._save_jrys_data()  # 保存更新后的 jrys_data
+
             # 标记当前背景图已由 jrys_data 管理，不要在 finally 中清理
-            background_should_cleanup = False 
+            background_should_cleanup = False
 
         except Exception as e:
             logger.error(f"生成运势图片过程中出错: {e}")
@@ -182,7 +201,7 @@ class JrysPlugin(Star):
             if temp_file_path and os.path.exists(temp_file_path):
                 try:
                     await aiofiles.os.remove(temp_file_path)
-                    logger.info(f"成功删除临时文件")
+                    logger.info("成功删除临时文件")
 
                 except OSError as e:
                     logger.warning(f"删除临时文件 {temp_file_path} 失败: {e}")
@@ -220,5 +239,3 @@ class JrysPlugin(Star):
             logger.info("HTTP会话已关闭")
 
         logger.info("今日运势插件已终止")
-
-

--- a/resources.py
+++ b/resources.py
@@ -18,25 +18,27 @@ import os
 
 ONE_DAY_IN_SECONDS = 86400
 
+
 class ResourceManager:
     """
     资源管理器，负责用户头像和背景图片的获取、缓存和管理
     """
-    def __init__(self, plugin_config) -> None:
+
+    def __init__(self, plugin_config, plugin_name: Optional[str] = None) -> None:
         self._http_timeout = aiohttp.ClientTimeout(total=5)  # 设置请求超时时间为5秒
         self._connection_limit = aiohttp.TCPConnector(limit=10)  # 限制并发连接数为10
         self._session = aiohttp.ClientSession(
             timeout=self._http_timeout, connector=self._connection_limit
         )
         self.plugin_config = plugin_config
+        self.name = plugin_name or "astrbot_plugin_jrysprpr"
 
         self.avatar_cache_expiration = self.plugin_config.get(
             "avatar_cache_expiration", ONE_DAY_IN_SECONDS
         )  # 默认一天过期
 
-        
         # 初始化jrys数据
-       
+
         self.is_data_loaded = False
 
         self._storage_initialized = False
@@ -45,13 +47,11 @@ class ResourceManager:
         self._background_tmp_dir: Optional[Path] = None
         self._precache_task: Optional[asyncio.Task] = None
 
-
         self.data_dir = os.path.dirname(os.path.abspath(__file__))
         self.avatar_dir = os.path.join(self.data_dir, "avatars")
         self.background_dir = os.path.join(self.data_dir, "backgroundFolder")
         self.font_dir = os.path.join(self.data_dir, "font")
-        
-        
+
         self._http_headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"
         }
@@ -85,7 +85,6 @@ class ResourceManager:
 
             # 从选中的 txt 文件中随机选择一行
             async with aiofiles.open(background_file_path, "r", encoding="utf-8") as f:
-
                 # 读取文件内容
                 background_urls = [line.strip() async for line in f if line.strip()]
 
@@ -124,7 +123,9 @@ class ResourceManager:
                         image_path = self._background_tmp_path_for_url(image_url)
                         should_cleanup = True
 
-                    ok = await self._download_to_path(image_url, image_path, label="背景图")
+                    ok = await self._download_to_path(
+                        image_url, image_path, label="背景图"
+                    )
                     if ok:
                         logger.info(f"下载图片成功: {image_url}")
                         return str(image_path), should_cleanup
@@ -177,8 +178,6 @@ class ResourceManager:
             logger.error(f"获取用户头像失败: {e}")
             return None
 
-
-
     async def initialize(self):
         """插件加载/重载后执行（适合做缓存预热等异步任务）。"""
         self._ensure_storage_dirs()
@@ -186,7 +185,9 @@ class ResourceManager:
         if self.plugin_config.get("pre_cache_background_images", False):
             self._start_background_precache()
 
-    def _migrate_legacy_cache_dir(self, legacy_dir: Path, target_dir: Path, label: str) -> None:
+    def _migrate_legacy_cache_dir(
+        self, legacy_dir: Path, target_dir: Path, label: str
+    ) -> None:
         """将旧版本缓存目录迁移到标准插件数据目录。"""
         try:
             if not legacy_dir.exists() or not legacy_dir.is_dir():
@@ -262,9 +263,13 @@ class ResourceManager:
         try:
             from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
-            plugin_name = getattr(self, "name", None) or "unknown"
+            plugin_name = (
+                self.name or getattr(self, "name", None) or "astrbot_plugin_jrysprpr"
+            )
             data_root = get_astrbot_data_path()
-            data_root_path = data_root if isinstance(data_root, Path) else Path(str(data_root))
+            data_root_path = (
+                data_root if isinstance(data_root, Path) else Path(str(data_root))
+            )
             plugin_data_dir = data_root_path / "plugin_data" / plugin_name
             plugin_data_dir.mkdir(parents=True, exist_ok=True)
 
@@ -289,7 +294,9 @@ class ResourceManager:
                 plugin_data_dir / "avatars",
             ]
             for legacy_dir in legacy_avatar_dirs:
-                self._migrate_legacy_cache_dir(legacy_dir, target_avatar_dir, label="头像")
+                self._migrate_legacy_cache_dir(
+                    legacy_dir, target_avatar_dir, label="头像"
+                )
 
             legacy_background_dirs = [
                 Path(self.background_dir) / "images",  # 旧 fallback 结构
@@ -334,7 +341,9 @@ class ResourceManager:
                 Path(self.data_dir) / "avatars",
             ]
             for legacy_dir in legacy_avatar_dirs:
-                self._migrate_legacy_cache_dir(legacy_dir, target_avatar_dir, label="头像")
+                self._migrate_legacy_cache_dir(
+                    legacy_dir, target_avatar_dir, label="头像"
+                )
 
             legacy_background_dirs = [
                 Path(self.background_dir) / "images",
@@ -395,7 +404,9 @@ class ResourceManager:
             tmp_path = dest.parent / f"{dest.name}.{uuid4().hex}.tmp"
 
             try:
-                async with self._session.get(url, headers=self._http_headers) as response:
+                async with self._session.get(
+                    url, headers=self._http_headers
+                ) as response:
                     status = response.status
                     reason = (response.reason or "").strip()
 
@@ -491,7 +502,9 @@ class ResourceManager:
         for background_file in background_files:
             background_file_path = os.path.join(self.background_dir, background_file)
             try:
-                async with aiofiles.open(background_file_path, "r", encoding="utf-8") as f:
+                async with aiofiles.open(
+                    background_file_path, "r", encoding="utf-8"
+                ) as f:
                     async for line in f:
                         url = line.strip()
                         if not url:
@@ -595,7 +608,6 @@ class ResourceManager:
             f"预缓存背景图完成: total={total}, cached={already_cached}, downloaded={downloaded}, failed={failed}"
         )
 
-           
     async def _load_jrys_data(self) -> dict:
         """
         初始化 jrys.json 文件
@@ -639,10 +651,9 @@ class ResourceManager:
         jrys_path = os.path.join(self.data_dir, "jrys.json")
         try:
             async with aiofiles.open(jrys_path, "w", encoding="utf-8") as f:
-                content = await asyncio.to_thread(json.dumps, self.jrys_data, ensure_ascii=False, indent=4)
+                content = await asyncio.to_thread(
+                    json.dumps, self.jrys_data, ensure_ascii=False, indent=4
+                )
                 await f.write(content)
         except Exception as e:
             logger.error(f"保存运势数据失败: {e}")
-
-
-


### PR DESCRIPTION
修复了运势缓存目录命名问题，并将资源管理器初始化接入插件异步生命周期。

**缓存目录名修复：**

* `ResourceManager` 构造函数新增 `plugin_name` 参数，用于正确标识插件数据目录名称，避免缓存写入错误路径。
* `_ensure_storage_dirs` 中 `plugin_name` 的获取逻辑改为优先使用构造时传入的 `plugin_name`，兜底为 `"astrbot_plugin_jrysprpr"`，确保缓存目录名称稳定一致。

**资源初始化调整：**

* 新增 `initialize` 异步生命周期方法，在插件加载/重载后统一执行存储目录初始化及背景图预缓存启动逻辑。
* `JrysPlugin` 新增 `initialize` 方法，在插件启动时调用 `await self.resources.initialize()`，确保资源管理器在插件生命周期内正确完成初始化。